### PR TITLE
Clear CacheID on logout before wiping credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ wct.conf.js
 npm-debug.log
 bower_components
 node_modules
+yarn-error.log

--- a/aws-cognito.html
+++ b/aws-cognito.html
@@ -240,6 +240,7 @@ Example usage:
         this._log.info(`Logging out user ${cognitoUser.username}`);
         this._shouldRefreshUser = false;
         cognitoUser.signOut();
+        AWS.config.credentials.clearCachedId(); // https://github.com/aws/aws-sdk-js/issues/609
         AWS.config.credentials = {};
         cognitoUser = null;
         this.loggedIn = false;


### PR DESCRIPTION
closes #15.

Not sure if anything else needs to be done to clear credentials cache on instances at the same time.