### PR TITLE
Bugfix/events composed

### DIFF
--- a/aws-cognito.html
+++ b/aws-cognito.html
@@ -79,7 +79,6 @@ Example usage:
           readOnly: true,
           value: null,
           notify: true,
-          observer: '_dispatchCognitoUser',
         },
 
         /**
@@ -90,7 +89,6 @@ Example usage:
           readOnly: true,
           value: null,
           notify: true,
-          observer: '_dispatchCognitoAttributes',
         },
 
         /**
@@ -134,6 +132,11 @@ Example usage:
 
       behaviors: [
         PolymerElements.LogBehavior,
+      ],
+
+      observers: [
+        '_userChanged(user, identityId)',
+        '_attributesChanged(attributes)',
       ],
 
       ready: function() {
@@ -184,9 +187,13 @@ Example usage:
       verify: function(username, code) {
         this._confirmRegistration(username, code)
         .then((result) =>
-          this.dispatchEvent(new CustomEvent('confirm-success', {detail: result})))
+          this.dispatchEvent(new CustomEvent('confirm-success', {
+            detail: result, bubbles: true, composed: true,
+          })))
         .catch((error) =>
-          this.dispatchEvent(new CustomEvent('confirm-failure', {detail: error})));
+          this.dispatchEvent(new CustomEvent('confirm-failure', {
+            detail: error, bubbles: true, composed: true,
+          })));
       },
 
       /**
@@ -218,13 +225,15 @@ Example usage:
           .then(() => {
             // Begin automatically refreshing user unless asked not to
             this._shouldRefreshUser = this.noAutoRefresh ? false : true;
-            this.dispatchEvent(new CustomEvent('login-success', {detail: username}));
+            this.dispatchEvent(new CustomEvent('login-success', {
+              detail: username, bubbles: true, composed: true,
+            }));
             resolve({message: 'Successfully logged In', username: username});
           })
           .catch((error) => {
             this._handleError(error);
             this.dispatchEvent(new CustomEvent('login-failure', {
-              detail: error,
+              detail: error, bubbles: true, composed: true,
             }));
           });
         });
@@ -246,7 +255,7 @@ Example usage:
         this.loggedIn = false;
         this._setIdentityId(null);
         this._setLoggedIn(false);
-        this._dispatchCognitoUser({username: null});
+        this._setUser({username: null});
       },
 
       /**
@@ -269,9 +278,10 @@ Example usage:
             const username = cognitoUser.username;
             this._log.info( `Cognito user ${cognitoUser.username} found. Trying to recover` );
             this._recoverUser(cognitoUser)
-            // .then(() => this._dispatchCognitoUser(cognitoUser))
             .then(() => {
-              this.dispatchEvent(new CustomEvent('restore-session-success', {detail: username}));
+              this.dispatchEvent(new CustomEvent('restore-session-success', {
+                detail: username, bubbles: true, composed: true,
+              }));
               this._shouldRefreshUser = !this.noAutoRefresh? true : false;
             })
             .then(() => {
@@ -281,7 +291,9 @@ Example usage:
             .then(() => this._getCognitoAttributes(cognitoUser))
             .then((attributes) => this._setAttributes(attributes))
             .catch((error) => {
-              this.dispatchEvent(new CustomEvent('restore-session-failure', {detail: username}));
+              this.dispatchEvent(new CustomEvent('restore-session-failure', {
+                detail: username, bubbles: true, composed: true,
+              }));
               reject(error);
             });
           }
@@ -326,7 +338,7 @@ Example usage:
         return new Promise((resolve, reject) => {
           this._getCognitoAttributes(cognitoUser)
           .then((attributes) => {
-            this._dispatchCognitoAttributes(attributes);
+            this._setAttributes(attributes);
             resolve(attributes);
           })
           .catch((error) => reject(error));
@@ -673,45 +685,31 @@ Example usage:
        * Dispatches an event containing all Cognito user data.
        *
        * @param  {CognitoUser}  cognitoUser The Cognito user.
-       * @param  {Object}       ov The previous value.
+       * @param  {String}       identityId  The user's identityId.
        * @fires  cognito-user
        */
-      _dispatchCognitoUser: function(cognitoUser, ov) {
-        if (!cognitoUser && !ov) return; // App is initializing
-        if (!cognitoUser) {
-          throw new Error(`No Cognito user found while dispatching user data`);
+      _userChanged: function(cognitoUser, identityId) {
+        if (AWS.config.credentials) {
+          this._log.debug(`Dispatching Cognito user ${cognitoUser.username}`);
+          this.dispatchEvent(new CustomEvent('cognito-user', {
+            detail: {user: cognitoUser, identityId}, bubbles: true, composed: true,
+          }));
+        } else {
+          throw new Error('No Cognito user credentials found while dispatching user');
         }
-        if (!AWS.config.credentials) {
-          throw new Error( `No Cognito user credentials found while dispatching user` );
-        }
-        this._log.debug(`Dispatching Cognito user ${cognitoUser.username}`);
-
-        const cognitoUserEvent = new CustomEvent('cognito-user', {
-          detail: {user: cognitoUser, identityId: this.identityId},
-          bubbles: true,
-          composed: true,
-        });
-        this.dispatchEvent(cognitoUserEvent);
       },
 
       /**
        * Dispatches an event containing updated user attributes.
        *
        * @param  {CognitoAttributes} attributes The updated attributes.
-       * @return {CognitoAttributes}            The updated attributes.
        * @fires  cognito-attributes
        */
-      _dispatchCognitoAttributes: function(attributes) {
-        if (attributes) {
-          this._log.debug(`Dispatching Cognito attributes`);
-          const cognitoAttributesEvent = new CustomEvent('cognito-attributes', {
-            // detail: formattedAttributes, bubbles: true, composed: true,
-            detail: attributes, bubbles: true, composed: true,
-          });
-          this.dispatchEvent(cognitoAttributesEvent);
-
-          return attributes;
-        }
+      _attributesChanged: function(attributes) {
+        this._log.debug(`Dispatching Cognito attributes`);
+        this.dispatchEvent(new CustomEvent('cognito-attributes', {
+          detail: attributes, bubbles: true, composed: true,
+        }));
       },
 
       /**
@@ -726,12 +724,10 @@ Example usage:
           throw new Error('No credentials found while dispatching credentials');
         }
         this._log.debug('Dispatching Cognito credentials');
-        const cognitoCredentials = new CustomEvent('cognito-credentials', {
-          detail: {credentials, cognitoUser, cognitoSession},
-          bubbles: true,
-          composed: true,
-        });
-        this.dispatchEvent(cognitoCredentials);
+        const detail = {credentials, cognitoUser, cognitoSession};
+        this.dispatchEvent(new CustomEvent('cognito-credentials', {
+          detail, bubbles: true, composed: true,
+        }));
       },
     });
     /**

--- a/aws-cognito.html
+++ b/aws-cognito.html
@@ -531,7 +531,9 @@ Example usage:
        * @param  {Object} error Error object. Should contain `message` key.
        */
       _handleError: function(error) {
-        this.dispatchEvent(new ErrorEvent('error', {error, bubbles: true, composed: true}));
+        error.bubbles = true;
+        error.composed = true;
+        this.dispatchEvent(new ErrorEvent('error', error));
       },
 
       /**

--- a/aws-cognito.html
+++ b/aws-cognito.html
@@ -531,7 +531,7 @@ Example usage:
        * @param  {Object} error Error object. Should contain `message` key.
        */
       _handleError: function(error) {
-        this.dispatchEvent(new ErrorEvent('error', error));
+        this.dispatchEvent(new ErrorEvent('error', {error, bubbles: true, composed: true}));
       },
 
       /**

--- a/aws-cognito.html
+++ b/aws-cognito.html
@@ -77,7 +77,6 @@ Example usage:
         user: {
           type: Object,
           readOnly: true,
-          value: null,
           notify: true,
         },
 
@@ -87,7 +86,6 @@ Example usage:
         attributes: {
           type: Array,
           readOnly: true,
-          value: null,
           notify: true,
         },
 
@@ -97,7 +95,6 @@ Example usage:
         identityId: {
           type: String,
           readOnly: true,
-          value: null,
           notify: true,
         },
 

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-app",
+  "name": "polymeraws",
   "version": "1.0.2",
   "authors": [
     "Joachim den Hertog",


### PR DESCRIPTION
This PR introduces an important bug fix, namely, ensuring that all events fire with `bubbles: true, composed: true`, in order to break the shadowDom barrier. It also refactors two of the event dispatchers to be observers, thus saving lines of code.

It also changes the bower package name to `polymeraws`